### PR TITLE
syscall.O_NONBLOCK on file open

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func work(p string) error {
 		decrementCurrentlyWorkingWorkers()
 	}()
 
-	f, err := os.OpenFile(p, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	f, err := os.OpenFile(p, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
 	if err != nil {
 		if errors.Is(err, syscall.ELOOP) {
 			return nil // this is O_NOFOLLOW result, we tried to open a symlink, ignore


### PR DESCRIPTION
Hi,
When i tried to dedupe my home folder, it got stuck with queue 0 and 5 workers (let it sit for 1 hour)
after looking with the go debugger i saw it got stuck at the open command
so i added the syscall.O_NONBLOCK flag and now it dedupes not only my home folder, but my whole SSD without a problem